### PR TITLE
Let Xdebug work without specific settings for different OSes + some slight improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,9 +212,11 @@ RUN apk --no-cache add git openssh bash; \
  # Enable Xdebug
  docker-php-ext-enable xdebug
 
-# For Xdebuger to work, it needs the docker host ID
+# For Xdebuger to work, it needs the docker host IP
 # - in Mac AND Windows, `host.docker.internal` resolve to Docker host IP
 # - in Linux, `172.17.0.1` is the host IP
+# By default, `host.docker.internal` is set as extra host in docker-compose.yml, so it also works in Linux without any
+# additional setting. This env is reserved for people who want to customize their own compose configuration.
 ENV XDEBUG_CLIENT_HOST="host.docker.internal"
 
 # ---------------------------------------------------- Scripts ---------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ COMMAND ?= /bin/sh
 
 # --------------------------
 
-.PHONY: build deploy start stop logs restart shell up rm help
+.PHONY: deploy up build-up build down start stop logs images ps command \
+	command-root shell-root shell restart rm help
 
 deploy:			## Start using Prod Image in Prod Mode
 	${COMPOSE_PREFIX_CMD} docker-compose -f docker-compose.prod.yml up --build -d

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ command-root:	 ## Execute command as root ( make command-root COMMAND=<command> 
 	@${COMPOSE_PREFIX_CMD} docker-compose run --rm -u root app ${COMMAND}
 
 shell-root:			## Enter container shell as root
-	@${COMPOSE_PREFIX_CMD} docker-compose exec -u root app /bin/bash
+	@${COMPOSE_PREFIX_CMD} docker-compose exec -u root app /bin/sh
 
 shell:			## Enter container shell
-	@${COMPOSE_PREFIX_CMD} docker-compose exec app /bin/bash
+	@${COMPOSE_PREFIX_CMD} docker-compose exec app /bin/sh
 
 restart:		## Restart container
 	@${COMPOSE_PREFIX_CMD} docker-compose restart

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Your application will be split into two components.
 
 # Requirements 
 
-- [Docker 20.05 or higher](https://docs.docker.com/install/) 
+- [Docker 20.10.0 or higher](https://docs.docker.com/install/) 
 - [Docker-Compose 1.27 or higher](https://docs.docker.com/compose/install/) (optional)
 - PHP >= 7 Application
 
@@ -197,11 +197,6 @@ In `docker/` directory there is `post-build-*` and `pre-run-*` scripts that are 
       Version, will try to access the DB at php's script initialization (even at the post-install cmd's), and it will
       fail when it cannot connect to
       DB. [Make sure you configure doctrine to avoid this extra DB Check connection.](https://symfony.com/doc/current/reference/configuration/doctrine.html#:~:text=The-,server_version,-option%20was%20added)
-
-3. Xdebug not working
-
-    - Xdebug is configured to work with Linux, to make it work for Mac/Windows, please change `XDEBUG_CLIENT_HOST` env
-      variable to `host.docker.internal` in `docker-compose.yml` file.
 
 # License 
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 ## How to use with my project ?
 
-- Copy this repository `Dockerfile`, `docker` Directory, `Makefile`, and `.dockerignore` to your application root directory and configure it to your needs.
+- Copy this repository `Dockerfile`, `docker` Directory, `Makefile`, `docker-compose.yml`, `docker-compose.prod.yml` and `.dockerignore` to your application root directory and configure it to your needs.
 
 ## How to configure image to run my project ?
 
@@ -88,7 +88,7 @@ Your application will be split into two components.
 #### 1. Add Template to your repo.
 
 1. Download This Repository
-2. Copy `Dockerfile`, `docker` Directory, `Makefile`, and `.dockerignore` Into your Application Repository.
+2. Copy `Dockerfile`, `docker` Directory, `Makefile`, `docker-compose.yml`, `docker-compose.prod.yml` and `.dockerignore` Into your Application Repository.
 
 OR
 
@@ -114,18 +114,18 @@ OR
 However, in an environment where CI/CD pipelines will build the image, they will need to supply some build-time arguments for the image. (tho defaults exist.)
     
     #### Build Time Arguments
-  | **ARG**            | **Description**
-  | **Default** |
-  --------------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-  | `PHP_VERSION`      | PHP Version used in the Image | `7.4`     | | `PHP_ALPINE_VERSION`                | Alpine
-  Version for the PHP Image | `3.15`     | | `NGINX_VERSION`    | Nginx Version | `1.21`    | | `COMPOSER_VERSION` |
-  Composer Version used in Image | `2.0`     | | `COMPOSER_AUTH`    | A Json Object with Bitbucket or Github token to
-  clone private Repos with composer.</br>[Reference](https://getcomposer.org/doc/03-cli.md#composer-auth) | `{}`
-  | | `RUNTIME_DEPS`     | List of all OS Packages needed for PHP Runtime | `zip`        | | `XDEBUG_VERSION`   | Xdebug
-  Version to use in Development Image | `3.0.3`        |
 
-      #### Image Targets
-    
+    | **ARG**              | **Description** | **Default** |
+    |----------------------|-----------------|-------------|
+    | `PHP_VERSION`        | PHP Version used in the Image | `7.4` |
+    | `PHP_ALPINE_VERSION` | Alpine Version for the PHP Image | `3.15` |
+    | `NGINX_VERSION`      | Nginx Version | `1.21` |
+    | `COMPOSER_VERSION`   | Composer Version used in Image | `2.0` |
+    | `COMPOSER_AUTH`      | A Json Object with Bitbucket or Github token to clone private Repos with composer.</br>[Reference](https://getcomposer.org/doc/03-cli.md#composer-auth) | `{}` |
+    | `XDEBUG_VERSION`     | Xdebug Version to use in Development Image | `3.1.3` |
+
+    #### Image Targets
+
     | **Target** | Env         | Desc                                                                                                                                                                                                                                                                             | Size   | Based On                      |
     |------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|-------------------------------|
     | app        | Production  | The PHP Application with immutable code/dependencies. By default starts `PHP-FPM` process listening on `9000`.  Command can be extended to run any PHP Consumer/Job, entrypoint will still start the pre-run setup and then run the supplied command.                            | ~135mb | PHP Official Image (Alpine)   |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,8 @@ services:
         COMPOSER_AUTH: "{}"
         APP_BASE_DIR: ${APP_BASE_DIR-.}
     restart: unless-stopped
-    environment:
-      # For Xdebuger to work, it needs the docker host ID
-      # - in Mac AND Windows, `host.docker.internal` resolve to Docker host IP
-      # - in Linux, `172.17.0.1` is the host IP
-      XDEBUG_CLIENT_HOST: ${XDEBUG_CLIENT_HOST-host.docker.internal}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ${APP_BASE_DIR-.}:/app
 

--- a/docker/fpm/fpm.conf
+++ b/docker/fpm/fpm.conf
@@ -18,7 +18,6 @@ pm = dynamic
 pm.start_servers = 2
 pm.min_spare_servers  = 2
 pm.max_spare_servers = 2
-pm.process_idle_timeout = 10s
 pm.max_children = 50
 
 ; do not clear environment variables sent to the PHP Script, pass OS env vars to PHP. (Important for K8S)

--- a/docker/fpm/fpm.conf
+++ b/docker/fpm/fpm.conf
@@ -24,7 +24,7 @@ pm.max_children = 50
 ; do not clear environment variables sent to the PHP Script, pass OS env vars to PHP. (Important for K8S)
 clear_env = no
 
-; Disable access logs in fpm's stdout/err as it will be in nginx acces logs.
+; Disable access logs in fpm's stdout/err as it will be in nginx access logs.
 ;access.log = /dev/stderr
 
 ; Run as www-data


### PR DESCRIPTION
Thanks to this repository, I learnt a lot about the combination of nginx and php-fpm.
Here's something I think that could probably be improved when reading the configs.

---

What does this implement/fix? Explain your changes.
---------------------------------------------------
* Let Xdebug work without specific settings for different OSes
* Improve README
* Fix typo in a comment
* Add missing Makefile targets in .PHONY and reorder it
* Remove unused fpm config: `pm.process_idle_timeout`
* Use `/bin/sh` instead for shell commands in the Makefile

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.

Where has this been tested?
---------------------------
1. Ubuntu 20.04.4 LTS + Docker 20.10.14
2. macOS Big Sur 11.6.6 + Docker Desktop 4.8.2 (Docker 20.10.14)
